### PR TITLE
Add MCA check

### DIFF
--- a/globals.sh
+++ b/globals.sh
@@ -13,7 +13,8 @@ PKGS_DIR="${REPO_DIR}/x86_64/os/packages"
 MIX_INCREMENT=${MIX_INCREMENT:-10}
 
 BUILD_FILE=build-env
+BUNDLES_FILE=bundles-def
+MCA_FILE=mca-report
 PKG_LIST_FILE=packages-nvr
 PKG_LIST_TMP=packages_
 RELEASE_NOTES=release-notes
-BUNDLES_FILE=bundles-def

--- a/release/ReleasePipeline
+++ b/release/ReleasePipeline
@@ -21,6 +21,7 @@ pipeline {
         stage('Create Update Stream') {
             steps {
                 sh 'release/mixer.sh'
+                sh 'release/mca-check.sh'
             }
         }
         stage('Create Images') {

--- a/release/mca-check.sh
+++ b/release/mca-check.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright (C) 2018 Intel Corporation
+
+# shellcheck source=globals.sh
+# shellcheck source=common.sh
+
+# MCA_VERSIONS: Space separated list of versions that MCA will execute.
+#               It will compare each pair of adjacent versions in the list.
+#               If MCA_VERSIONS contains a single version, it will not run.
+
+set -e
+set -o pipefail
+
+SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+
+. "${SCRIPT_DIR}/../globals.sh"
+. "${SCRIPT_DIR}/../common.sh"
+
+. ./config/config.sh
+
+var_load MCA_VERSIONS
+
+# shellcheck disable=2206
+mca_versions=(${MCA_VERSIONS}) # Make an array
+
+# ==============================================================================
+# MAIN
+# ==============================================================================
+stage "Manifest Correctness Assurance"
+
+if (( ${#mca_versions[@]} <= 1 )); then
+    log "No previous versions to compare" "Skipping it. First Mix?"
+    exit 0
+fi
+
+# Perform MCA check for each version against its previous version.
+# Format bumps create multiple MCA logs.
+pushd "${BUILD_DIR}" > /dev/null
+prev_ver="${mca_versions[0]}"
+for ver in "${mca_versions[@]:1}"; do
+    mca_log="${WORK_DIR}/${MCA_FILE}-${prev_ver}-${ver}.txt"
+
+    section "Report from '${prev_ver}' to '${ver}'"
+    log_line
+
+    sudo -E mixer --native build validate --from "${prev_ver}" --to "${ver}" | tee "${mca_log}"
+
+    # Remove cached RPMs that won't be reused
+    sudo rm -rf "update/validation/${prev_ver}"
+
+    prev_ver="${ver}"
+done
+popd > /dev/null

--- a/release/mixer.sh
+++ b/release/mixer.sh
@@ -199,6 +199,8 @@ if [[ -z ${DS_LATEST} ]]; then
     var_save DS_UP_VERSION
 fi
 
+MCA_VERSIONS="${DS_LATEST}"
+
 section "Preparing Downstream Content"
 fetch_bundles # Download the Downstream Bundles Repository
 
@@ -247,6 +249,8 @@ for (( bump=0 ; bump < format_bumps ; bump++ )); do
     log "+10 Mix:" "${ds_ver} (${ds_fmt}) based on: ${up_ver} (${up_fmt})"
     log "+20 Mix:" "${ds_ver_next} (${ds_fmt_next}) based on: ${up_ver_next} (${up_fmt_next})"
     generate_bump "${up_ver}" "${ds_ver}" "${ds_fmt}" "${up_ver_next}" "${ds_ver_next}" "${ds_fmt_next}"
+
+    MCA_VERSIONS+=" ${ds_ver} ${ds_ver_next}"
 done
 
 if [[ -n "${ds_fmt_next}" ]]; then
@@ -258,6 +262,8 @@ if [[ -z "${ds_ver_next}" || "${MIX_VERSION}" -gt "${ds_ver_next}" ]]; then
     log_line
     log "Regular Mix:" "${MIX_VERSION} (${DS_FORMAT}) based on: ${CLR_LATEST} (${CLR_FORMAT})"
     generate_mix "${CLR_LATEST}" "${MIX_VERSION}" "${DS_FORMAT}"
+
+    MCA_VERSIONS+=" ${MIX_VERSION}"
 else
     MIX_VERSION=${ds_ver_next}
     # shellcheck disable=SC2034
@@ -269,5 +275,7 @@ else
     var_save MIX_UP_VERSION
     var_save MIX_DOWN_VERSION
 fi
+
+var_save MCA_VERSIONS
 
 popd > /dev/null

--- a/release/stage.sh
+++ b/release/stage.sh
@@ -36,6 +36,8 @@ log_line "Finishing 'release' folder"
 mv "${WORK_DIR}/${BUILD_FILE}" "${release_dir}/${BUILD_FILE}-${MIX_VERSION}.txt"
 mv "${WORK_DIR}/${PKG_LIST_FILE}" "${release_dir}/${PKG_LIST_FILE}-${MIX_VERSION}.txt"
 mv "${WORK_DIR}/${RELEASE_NOTES}" "${release_dir}/${RELEASE_NOTES}-${MIX_VERSION}.txt"
+mv "${WORK_DIR}/${MCA_FILE}-"*.txt "${release_dir}/" || true # prevents failure when no MCA logs exist.
+
 mv "${REPO_DIR}/" "${release_dir}/repo/"
 cp -a "${BUILD_DIR}/Swupd_Root.pem" "${release_dir}/config/"
 git -C "${bundles_dir}" archive --format='tar.gz' --prefix='bundles/' \


### PR DESCRIPTION
MCA compares a mix against its previous mix to identify file
modification inconsistencies between manifests and the RPMs used to
generate them. Any inconsistencies are reported as errors and package
statistics are reported on success.

Signed-off-by: John Akre <john.w.akre@intel.com>