### PR TITLE
Give a chance to add local rpms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ koji_STEPS := $(patsubst %.sh,%,$(notdir $(koji_SRC)))
 
 release_CHECKOPTS := --exclude=2013,2024,2155
 release_SRC := $(wildcard $(CURDIR)/release/*.sh)
-release_STEPS := prologue content mixer mca-check images release_notes stage #skipping: koji publish
+release_STEPS := prologue local content mixer mca-check images release_notes stage #skipping: koji publish
 
 watcher_SRC := $(wildcard $(CURDIR)/watcher/*.sh)
 watcher_STEPS := $(patsubst %.sh,%,$(notdir $(watcher_SRC)))

--- a/release/ReleasePipeline
+++ b/release/ReleasePipeline
@@ -14,6 +14,7 @@ pipeline {
         }
         stage('Setup Content') {
             steps {
+                sh 'release/local.sh'
                 sh 'release/content.sh'
             }
         }

--- a/release/local.sh
+++ b/release/local.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright (C) 2018 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# shellcheck source=common.sh
+
+set -e
+
+SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+
+. "${SCRIPT_DIR}/../common.sh"
+
+. ./config/config.sh
+
+# ==============================================================================
+# MAIN
+# ==============================================================================
+stage "Content Provider - local"
+
+pkg_list="${WORK_DIR}/${PKG_LIST_TMP}local"
+
+if [[ -n ${LOCAL_RPM_PATH} && -d ${LOCAL_RPM_PATH} ]]; then
+    log_line "Copying local packages from ${LOCAL_RPM_PATH}"
+    cp "${LOCAL_RPM_PATH}"/*.rpm "${PKGS_DIR}"/
+    for file in "${LOCAL_RPM_PATH}"/*.rpm; do
+        rpm=$(basename "$file" .rpm)
+        echo "${rpm%.*}" >> "${pkg_list}"
+    done
+else
+    log_line "No LOCAL_RPM_PATH defined."
+fi


### PR DESCRIPTION
Many users don't reply on the koji to generate local
packages. They usually put the local packages in some
local place. Once define LOCAL_RPM_PATH, copy the rpms
in this path as local rpms.

Signed-off-by: Qi Zheng <qi.zheng@intel.com>