### PR TITLE
[mca] Override content repo for `from` version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ koji_STEPS := $(patsubst %.sh,%,$(notdir $(koji_SRC)))
 
 release_CHECKOPTS := --exclude=2013,2024,2155
 release_SRC := $(wildcard $(CURDIR)/release/*.sh)
-release_STEPS := prologue local content mixer images license_info release_notes stage #skipping: koji publish
+release_STEPS := prologue local content mixer mca-check images license_info release_notes stage #skipping: koji publish
 
 watcher_SRC := $(wildcard $(CURDIR)/watcher/*.sh)
 watcher_STEPS := $(patsubst %.sh,%,$(notdir $(watcher_SRC)))

--- a/globals.sh
+++ b/globals.sh
@@ -23,6 +23,7 @@ PKGS_DIR_SUFFIX="repo/${BUILD_ARCH}/os/packages"
 
 BUILD_FILE=build-env
 BUNDLES_FILE=bundles-def
+CONTENT_REPO=content
 MCA_FILE=mca-report
 PKG_LIST_FILE=packages-nvr
 PKG_LICENSES_FILE=packages-license-info

--- a/release/mca-check.sh
+++ b/release/mca-check.sh
@@ -36,12 +36,21 @@ fi
 pushd "${MIXER_DIR}" > /dev/null
 prev_ver="${mca_versions[0]}"
 for ver in "${mca_versions[@]:1}"; do
+    args="--from ${prev_ver} --to ${ver}"
     mca_log="${WORK_DIR}/${MCA_FILE}-${prev_ver}-${ver}.txt"
+
+    # The custom content repo for the initial previous version is
+    # staged, so the baseurl must be overridden to use the staged
+    # repo instead of the work repo.
+    if [[ "${prev_ver}" -eq "${mca_versions[0]}" ]]; then
+        args+=" --from-repo-url ${CONTENT_REPO}=file://${STAGING_DIR}/releases/${prev_ver}/repo/x86_64/os"
+    fi
 
     section "Report from '${prev_ver}' to '${ver}'"
     log_line
 
-    sudo -E mixer --native build validate --from "${prev_ver}" --to "${ver}" | tee "${mca_log}"
+    # shellcheck disable=2086
+    sudo -E mixer --native build validate ${args} | tee "${mca_log}"
 
     # Remove cached RPMs that won't be reused
     sudo rm -rf "update/validation/${prev_ver}"

--- a/release/mixer.sh
+++ b/release/mixer.sh
@@ -199,7 +199,7 @@ fi
 
 log_line "Checking Downstream Repo:"
 if [[ -n "$(ls -A "${PKGS_DIR}")" ]];then
-    mixer repo set-url content "file://${REPO_DIR}/x86_64/os" > /dev/null
+    mixer repo set-url "${CONTENT_REPO}" "file://${REPO_DIR}/x86_64/os" > /dev/null
     log_line "Content found. Adding it to the mix!" 1
 else
     log_line "Content not found. Skipping it." 1


### PR DESCRIPTION
MCA requires separate baseurl values for the custom content repo when
downloading packages for the `from` and `to` versions. This change
overrides the content repo basurl for the `from` version so that it
points to the staged content repo instead of the work repo.

Signed-off-by: John Akre <john.w.akre@intel.com>