### PR TITLE
[travis] Check 'make release' via Clear Linux container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,21 @@
-script:
-    - make check
+language: minimal
+
+service:
+  - docker
+
+before_install:
+  - uname -a
+  - pwd
+  - ip a
+  - df -h
+
+jobs:
+  include:
+    - stage: Static Analysis
+      script: make check
+
+    - stage: Make Release
+      install: docker build --quiet --build-arg UID=$(id -u) --network host --force-rm -t clr-builder .travis
+      script:
+        - docker run --rm -v $(pwd):/mnt clr-builder make release
+        - docker run --rm -v $(pwd):/mnt clr-builder make release

--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -1,0 +1,16 @@
+FROM clearlinux:latest
+LABEL maintainer="murilo.belluzzo@intel.com"
+
+RUN swupd bundle-add --quiet make network-basic mixer
+RUN swupd clean --quiet
+
+ARG UID=1000
+
+RUN useradd -G wheelnopw --uid ${UID} -U -m travis
+
+USER travis
+
+RUN git config --global user.email "travis@ci-container.com"
+RUN git config --global user.name "Travis"
+
+WORKDIR /mnt


### PR DESCRIPTION
Add a Dockerfile for a Clear Linux container which the require tools
and an appropriate user to be build by Travis-CI.

This allow us to validate 'make release' as well. CI will run 'make
release' twice to make sure code is working as intended for subsequent
releases since code path is different.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>