### PR TITLE
enable signing image feature

### DIFF
--- a/globals.sh
+++ b/globals.sh
@@ -33,3 +33,6 @@ RELEASE_NOTES=release-notes
 # List of words to be filtered out from $PKG_LICENSES_FILE as they are not real licenses
 # Space-separated
 LICENSES_FILTER=${LICENSES_FILTER-"and"}
+
+# sign_image requirements
+CHKSUM_FILE_SUFFIX=${CHKSUM_FILE_SUFFIX:-"SHA512SUM"}

--- a/release/prologue.sh
+++ b/release/prologue.sh
@@ -123,6 +123,7 @@ echo
 assert_dep mixer
 assert_dep clr-installer
 assert_dep swupd
+assert_dep sha512sum
 
 tee -a "${WORK_DIR}/${BUILD_FILE}" <<EOL
 == TOOLS ==


### PR DESCRIPTION
This feature by default uses a user generated private key
to generate the shasum of all the images and also provide
signing on the generated shasum.