### PR TITLE
[images] Use 'clr-installer' to create images

### DIFF
--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearlinux:latest
 LABEL maintainer="murilo.belluzzo@intel.com"
 
-RUN swupd bundle-add --quiet make network-basic mixer
+RUN swupd bundle-add --quiet make network-basic mixer clr-installer
 RUN swupd clean --quiet
 
 ARG UID=1000

--- a/release/ReleaseKojiPipeline
+++ b/release/ReleaseKojiPipeline
@@ -30,6 +30,7 @@ pipeline {
         }
         stage('Stage') {
             steps {
+                sh 'release/license_info.sh'
                 sh 'release/release_notes.sh'
                 sh 'release/stage.sh'
             }

--- a/release/prologue.sh
+++ b/release/prologue.sh
@@ -121,6 +121,7 @@ fi
 echo
 
 assert_dep mixer
+assert_dep clr-installer
 assert_dep swupd
 
 tee -a "${WORK_DIR}/${BUILD_FILE}" <<EOL
@@ -129,6 +130,8 @@ Clear Linux Version (on Builder):
     $(cat /usr/share/clear/version)
 Mixer Version:
     $(mixer --version)
+Clr-installer Version:
+    $(clr-installer --version)
 Swupd Version:
     $(swupd --version 2>&1 | head -1)
 


### PR DESCRIPTION
'ister.py' is being deprecated in favor of 'clr-installer' as image
generation tool.

'clr-installer' offers a helper command that translates old ister
templates in clr-installer templates, so it should be straight forward
for users of Clear Linux Distro Factory to migrate their configurations
when moving to a new release.

Therefore, there is no need for a transition period where both tools are
supported, so 'ister.py' support is completely removed by this patch.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>