### PR TITLE
BLOCKED: TESTING Travis - [travis] Use runc runtime for Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ jobs:
     - stage: Make Release
       install: docker build --quiet --build-arg UID=$(id -u) --network host --force-rm -t clr-builder .travis
       script:
-        - docker run --rm -v $(pwd):/mnt clr-builder make release
-        - docker run --rm -v $(pwd):/mnt clr-builder make release
+        - docker run --runtime=runc --rm -v $(pwd):/mnt clr-builder make release
+        - docker run --runtime=runc --rm -v $(pwd):/mnt clr-builder make release


### PR DESCRIPTION
The default Docker runtime in Clear is the kata runtime which does not
support host networking. This is a requirement for Mixer, so the runc
runtime must be used.

Signed-off-by: John Akre <john.w.akre@intel.com>