### PR TITLE
SimpleHTTPServer module has been merged into http.server in Python 3.…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ $(addprefix release/,$(release_STEPS)): config $(WORK_DIR)
 
 .PHONY: serve
 serve: $(STAGING_DIR)
-	cd $(STAGING_DIR); python -mSimpleHTTPServer
+	cd $(STAGING_DIR); python3 -m http.server
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
…0 which supports by Clear by default