### PR TITLE
Allow upstream bundles to be built

### DIFF
--- a/release/mixer.sh
+++ b/release/mixer.sh
@@ -51,9 +51,11 @@ build_bundles() {
     rm -f ./mixbundles
 
     log_line
-    # Add the upstream Bundle definitions for this base version of ClearLinux
-    # shellcheck disable=SC2086
-    mixer_cmd bundle add ${CLR_BUNDLES:-"--all-upstream"}
+    if ! "${IS_UPSTREAM}"; then
+        # Add the upstream Bundle definitions for this base version of ClearLinux
+        # shellcheck disable=SC2086
+        mixer_cmd bundle add ${CLR_BUNDLES:-"--all-upstream"}
+    fi
 
     # Add the downstream Bundle definitions
     # shellcheck disable=SC2086


### PR DESCRIPTION
When an upstream builds a mix, they will source all bundle definitions
locally.  Because upstream logic is largely different from downstream
logic when using mixer, introduce a flag that toggles the commands that
get run if one is an upstram vs a downstream.  If this flag is not
defined, the condition evaluates to false and the downstream logic is
maintained by default.

Also introduce a MIXER_OPTS variable so that upstream may be able to
define in its config that it also wants the offline option, but default
to the native option to preserve existing deployment logic.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>