### PR TITLE
Allow generate_bump function to work with upstream sources

### DIFF
--- a/release/mixer.sh
+++ b/release/mixer.sh
@@ -96,7 +96,14 @@ generate_bump() {
 
     # Remove bundles pending deletion
     section "Bundle Deletion"
-    for i in $(grep -lir "\\[STATUS\\]: Pending-Delete" upstream-bundles/ local-bundles/); do
+    local bundle_folders
+    if "${IS_UPSTREAM}"; then
+        bundle_folders="local-bundles/"
+    else
+        bundle_folders="upstream-bundles/ local-bundles/"
+    fi
+    # shellcheck disable=SC2086
+    for i in $(grep -lir "\\[STATUS\\]: Pending-Delete" ${bundle_folders}); do
         b=$(basename "$i")
         log "Deleting" "${b}"
         sudo -E rm -f "update/image/${mix_ver}/${b}-info"


### PR DESCRIPTION
Upstreams will never have a folder called upstream-bundles.  Need to
conditionally add this only when a downstream when grepping for bundles
that need deleted.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>