### PR TITLE
Account for different folder structures when fetching bundles

### DIFF
--- a/release/mixer.sh
+++ b/release/mixer.sh
@@ -20,9 +20,11 @@ SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 var_load_all
 
 fetch_bundles() {
-    log_line "Fetching downstream bundles:"
+    log_line "Fetching bundles:"
+    local bundles_dir="${WORK_DIR}/bundles"
+    git clone --quiet "${BUNDLES_REPO}" "${bundles_dir}"
     rm -rf ./local-bundles
-    git clone --quiet "${BUNDLES_REPO}" local-bundles
+    mv "${bundles_dir}/${BUNDLES_REPO_SRC_DIR}" ./local-bundles
     log_line "OK!" 1
 }
 


### PR DESCRIPTION
Bundle sources for an upstream need to go into local-bundles.  These
will come from the clr-bundles repository.  This repository stores
bundle definitions in the bundles folder, and cannot be cloned directly
into the local-bundles folder.  Allow for the folder where the bundle
definitions live to vary among repos via a config variable
BUNDLES_REPO_SRC_DIR.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>