### PR TITLE
Infer MIXER_OPTS automatically

### DIFF
--- a/release/mixer.sh
+++ b/release/mixer.sh
@@ -21,8 +21,12 @@ SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 var_load_all
 
 IS_UPSTREAM=${IS_UPSTREAM:-false}
+if "$IS_UPSTREAM"; then
+    MIXER_OPTS="--offline --native"
+else
+    MIXER_OPTS="--native"
+fi
 NUM_DELTA_BUILDS=${NUM_DELTA_BUILDS:-10}
-MIXER_OPTS=${MIXER_OPTS:-"--native"}
 
 mixer_cmd() {
     # shellcheck disable=SC2086


### PR DESCRIPTION
MIXER_OPTS should not be a user-configurable parameter because the
options passed to mixer are pre-determined if the user is an upstream or
a downstream.  If a user is an upstream, they will need both `--offline`
and `--native` whereas if a user is a downstream, they will need only
`--native`.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>