### PR TITLE
Generalizing post processing of image files

### DIFF
--- a/release/ReleasePipeline
+++ b/release/ReleasePipeline
@@ -25,7 +25,9 @@ pipeline {
         }
         stage('Create Images') {
             steps {
-                sh 'release/images.sh'
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    sh 'release/images.sh'
+                }
             }
         }
         stage('Stage') {

--- a/release/images.sh
+++ b/release/images.sh
@@ -22,40 +22,79 @@ LOG_DIR="${WORK_DIR}/logs"
 PROCS_PER_IMG=8
 TEMPLATES_PATH=${TEMPLATES_PATH:-"${PWD}/config/images"}
 
-sign_checksum() {
-    local chksum_file=$1
+checksum_and_sign() {
+    # ${1} - Where to output the list of files, checksum & signed files -> release dir
+    # ${2} - File path to image file
+    declare -n _output=${1}
+    local file_list=$2
 
-    if [[ -n "${IMG_SIGN_CMD}" ]]; then
-        log "Signing (custom)" "${chksum_file}"
-        "${IMG_SIGN_CMD}" "${chksum_file}" "${chksum_file}.sig"
-    elif [[ -s "${IMG_SIGN_KEY}" ]]; then
-        log "Signing (openssl)" "${chksum_file}"
-        openssl dgst -sha1 -sign "${IMG_SIGN_KEY}" -out "${chksum_file}.sig" "${chksum_file}"
-    else
-        warn "Skipping signing" "Neither custom signing command nor a signing key provided."
+    for file in ${file_list}; do
+        local chksum_file="${file}-${CHKSUM_FILE_SUFFIX}"
+
+        sha512sum "${file}" > "${chksum_file}"
+
+        if [[ -n "${IMG_SIGN_CMD}" ]]; then
+            log "Signing (custom)" "${chksum_file}"
+            "${IMG_SIGN_CMD}" "${chksum_file}" "${chksum_file}.sig"
+        elif [[ -s "${IMG_SIGN_KEY}" ]]; then
+            log "Signing (openssl)" "${chksum_file}"
+            openssl dgst -sha1 -sign "${IMG_SIGN_KEY}" -out "${chksum_file}.sig" "${chksum_file}"
+        else
+            warn "Skipping signing" "Neither custom signing command nor a signing key provided."
+        fi
+        _output+="${file} ${chksum_file} ${chksum_file}.sig " # space is not a mistake
+    done
+}
+
+finalize_image() {
+    # ${1} - Where to output the list of finalized images -> release dir
+    # ${2} - File path to image file
+    declare -n _output=${1}
+    local file_list=("${2}")
+    local name="$(basename "${file_list[0]}")"
+    local finalize_script="$(find "${TEMPLATES_PATH}" -name "${name%.*}-finalize.*" -print -quit)"
+
+    if [[ -z "${name}" ]]; then
+        error "Image finalization failed. Invalid input" "${2}"
+        return 1
     fi
+
+    for image_file in "${file_list[@]}"; do
+        if [[ -s "${finalize_script}" ]]; then
+            if ! image_file=$("${finalize_script}" "${image_file}"); then
+                warn "${name}" "Image finalization failed"
+                return 1
+            fi
+        fi
+
+        local final_path="$(dirname "${image_file}")/${DISTRO_NAME}-${MIX_VERSION}-$(basename "${image_file}")"
+        mv "${image_file}" "${final_path}"
+
+        _output+="${final_path} " # Space is not a mistake
+    done
 }
 
 create_image() {
-    # ${1} - File path to image template file
-    local image=${1}
+    # ${1} - Where to output the list of created images
+    # ${2} - File path to image template file
+    declare -n _output=${1}
+    local image=${2}
     local name=$(basename "${image%.yaml}")
     local log_file="${LOG_DIR}/clr-installer-${name}.log"
-    local final_file="${IMGS_DIR}/${DISTRO_NAME}-${MIX_VERSION}-${name}"
 
     if [[ -z "${image}" || -z "${name}" ]]; then
-        error "Image creation failed. Invalid input" "${1}"
+        error "Image creation failed. Invalid input" "${2}"
         return 1
     fi
 
     pushd "${WORK_DIR}" > /dev/null
+
     sudo -E clr-installer --config "${image}" --log-level=4 \
         --swupd-format "${DS_FORMAT}" --swupd-clean \
         --swupd-cert "${MIXER_DIR}/Swupd_Root.pem" \
         --swupd-contenturl "file://${MIXER_DIR}/update/www" \
         --swupd-versionurl "file://${MIXER_DIR}/update/www" \
         --log-file "${log_file}" &> /dev/null
-
     # cmd is way too large to embed on a 'if' statement
     # shellcheck disable=2181
     if (( $? )); then
@@ -66,25 +105,8 @@ create_image() {
         return 1
     fi
 
-    if [[ -s "${name}.img" ]]; then
-        xz -3 --stdout "${name}.img" > "${final_file}.img.xz"
-        sudo rm "${name}.img"
-
-        if [[ ! -s "${final_file}.img.xz" ]]; then
-            log "Image '${name}'" "Failed to create compressed file."
-            return 1
-        fi
-        sha512sum "${final_file}.img.xz" > "${final_file}.img.xz-${CHKSUM_FILE_SUFFIX}"
-        sign_checksum "${final_file}.img.xz-${CHKSUM_FILE_SUFFIX}"
-    fi
-
-    if [[ -s "${name}.iso" ]]; then
-        mv "${name}.iso" "${final_file}.iso"
-        sha512sum "${final_file}.iso" > "${final_file}.iso-${CHKSUM_FILE_SUFFIX}"
-        sign_checksum "${final_file}.iso-${CHKSUM_FILE_SUFFIX}"
-    fi
-
     popd > /dev/null
+    _output=$(ls "${WORK_DIR}/${name}".*)
     log "Image '${name}'" "OK!"
 }
 
@@ -94,7 +116,17 @@ parallel_fn() {
     . "${SCRIPT_DIR}/../common.sh"
     . "${SCRIPT_DIR}/../config/config.sh"
 
-    create_image "$@"
+    local image_files
+    local finalized_files
+    local final_files
+
+    create_image "image_files" "$@"
+    finalize_image "finalized_files" "${image_files}"
+    if checksum_and_sign "final_files" "${finalized_files}"; then
+        warn "$(basename "${image_files%.*}")" "Image signing failed"
+        return 1
+    fi
+    mv "${final_files}" "${IMGS_DIR}"
 }
 
 # ==============================================================================
@@ -118,8 +150,10 @@ export LOG_DIR
 export MIX_VERSION
 export DS_FORMAT
 export SCRIPT_DIR
+export TEMPLATES_PATH
 export -f create_image
-export -f sign_checksum
+export -f finalize_image
+export -f checksum_and_sign
 export -f parallel_fn
 procs=$(nproc --all)
 max_jobs=$(( ${procs:=0} > PROCS_PER_IMG ? procs / PROCS_PER_IMG : 1 ))


### PR DESCRIPTION
Image creation script has been modified to make image generation more
generic with support of adding custom finalize scripts in config repo.
This script searches & executes an image's finalize script if it exists.

If any of the image creation steps fail then the stage in pipeline is
set as failed but not the entire pipeline.

Signed-off-by: Vinay Potluri <vinay.potluri@intel.com>

Ref: https://github.com/clearlinux/clr-distro-factory/issues/41