### PR TITLE
[travis]: Add sudo as an explicit runtime requirement

### DIFF
--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearlinux:latest
 LABEL maintainer="murilo.belluzzo@intel.com"
 
-RUN swupd bundle-add --quiet make network-basic mixer clr-installer
+RUN swupd bundle-add --quiet make network-basic mixer clr-installer sudo
 RUN swupd clean --quiet
 
 ARG UID=1000


### PR DESCRIPTION
 Sudo is a utility that is required to run testing.  Make this explicit to make sure it does not get accidentally removed.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>