### PR TITLE
[travis]: Remove all cached files for swupd

### DIFF
--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -2,7 +2,7 @@ FROM clearlinux:latest
 LABEL maintainer="murilo.belluzzo@intel.com"
 
 RUN swupd bundle-add --quiet make network-basic mixer clr-installer
-RUN swupd clean --quiet
+RUN swupd clean --all --quiet
 
 ARG UID=1000
 


### PR DESCRIPTION
Do not want to keep any cached files for swupd around as a part of
testing in Travis CI.  This makes for a cleaner testing environment.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>