### PR TITLE
Update how variables are used for mixer.sh

### DIFF
--- a/globals.sh
+++ b/globals.sh
@@ -6,11 +6,21 @@
 NAMESPACE=${NAMESPACE:?"NAMESPACE cannot be Null/Unset"}
 WORK_DIR=${WORK_DIR:-"${PWD}/${NAMESPACE}/work"}
 
+# Distribution
+# If this update stream is either an upstream or a downstream
+IS_UPSTREAM=${IS_UPSTREAM:-false}
+# If this build should be a min version
+MIN_VERSION=${MIN_VERSION:-false}
+
 # Servers
 CLR_PUBLIC_DL_URL=${CLR_PUBLIC_DL_URL:-"https://download.clearlinux.org"}
 
 # Mixer
 MIX_INCREMENT=${MIX_INCREMENT:-10}
+# Global options to apply to all mixer calls
+MIXER_OPTS=${MIXER_OPTS:-""}
+# Number of builds from the current build to generate deltas
+NUM_DELTA_BUILDS=${NUM_DELTA_BUILDS:-10}
 
 # Workspace
 LOG_DIR="${WORK_DIR}/logs"

--- a/release/mixer.sh
+++ b/release/mixer.sh
@@ -4,8 +4,6 @@
 
 # CLR_BUNDLES: Subset of bundles to be used from upstream (instead of all)
 # DS_BUNDLES:  Subset of bundles to be used from downstream (instead of all)
-# IS_UPSTREAM: If this update stream is either an upstream or a downstream
-# MIN_VERSION: If this build should be a min version
 
 # shellcheck source=common.sh
 # shellcheck disable=SC2013
@@ -20,9 +18,9 @@ SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 
 var_load_all
 
-IS_UPSTREAM=${IS_UPSTREAM:-false}
-NUM_DELTA_BUILDS=${NUM_DELTA_BUILDS:-10}
-MIXER_OPTS=${MIXER_OPTS:-"--native"}
+if "${IS_UPSTREAM}" && [[ ${MIXER_OPTS} != *"--offline"* ]]; then
+    MIXER_OPTS="${MIXER_OPTS} --offline"
+fi
 
 mixer_cmd() {
     # shellcheck disable=SC2086
@@ -72,7 +70,7 @@ build_update() {
     local mix_ver="$1"
 
     section "Build 'Update' Content"
-    if ${MIN_VERSION:-false}; then
+    if "${MIN_VERSION}"; then
         sudo_mixer_cmd build update --skip-format-check --min-version="${mix_ver}"
     else
         sudo_mixer_cmd build update --skip-format-check


### PR DESCRIPTION
Mixer 6.0.0 removes support for running its build steps in a Docker
container as a means of maintaining backwards compatibility.  As a
result, the `--native` flag is deprecated and should be removed.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>