### PR TITLE
Provide mixer with a rpm folder

### DIFF
--- a/release/mixer.sh
+++ b/release/mixer.sh
@@ -232,7 +232,8 @@ fi
 
 log_line "Checking Downstream Repo:"
 if [[ -n "$(ls -A "${PKGS_DIR}")" ]];then
-    mixer_cmd repo set-url "${CONTENT_REPO}" "file://${REPO_DIR}/x86_64/os" > /dev/null
+    mixer_cmd config set Mixer.LOCAL_RPM_DIR "${REPO_DIR}/x86_64/os/Packages"
+    mixer_cmd add-rpms > /dev/null
     log_line "Content found. Adding it to the mix!" 1
 else
     log_line "Content not found. Skipping it." 1

--- a/release/prologue.sh
+++ b/release/prologue.sh
@@ -30,8 +30,8 @@ mkdir -p "${WORK_DIR}"/release/{config,images}
 mkdir -p "${PKGS_DIR}"
 
 mkdir -p "${MIXER_DIR}"
-rm -rf "${MIXER_DIR}/local-rpms" "${MIXER_DIR}/local-yum"
-mkdir -p "${MIXER_DIR}/local-rpms" "${MIXER_DIR}/local-yum"
+rm -rf "${MIXER_DIR}/local-yum"
+mkdir -p "${MIXER_DIR}/local-yum"
 
 mkdir -p "${STAGING_DIR}"
 log_line "OK!" 1


### PR DESCRIPTION
Code becomes fragile when it tries to manage mixer's workspace.  Code
should not be aware of mixer's internal folder structure and should
exclusively rely on mixer's interface for defining input for building an
update.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>