### PR TITLE
Use mixer function wrapper when running MCA

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -149,3 +149,13 @@ koji_cmd() {
     [[ -n "${result}" ]] && echo "${result}"
     return ${ret}
 }
+
+mixer_cmd() {
+    # shellcheck disable=SC2086
+    mixer ${MIXER_OPTS} "${@}"
+}
+
+sudo_mixer_cmd() {
+    # shellcheck disable=SC2086
+    sudo -E mixer ${MIXER_OPTS} "${@}"
+}

--- a/release/mca-check.sh
+++ b/release/mca-check.sh
@@ -50,7 +50,7 @@ for ver in "${mca_versions[@]:1}"; do
     log_line
 
     # shellcheck disable=2086
-    sudo -E mixer --native build validate ${args} | tee "${mca_log}"
+    sudo_mixer_cmd build validate ${args} | tee "${mca_log}"
 
     # Remove cached RPMs that won't be reused
     sudo rm -rf "update/validation/${prev_ver}"

--- a/release/mixer.sh
+++ b/release/mixer.sh
@@ -23,16 +23,6 @@ if "${IS_UPSTREAM}" && [[ ${MIXER_OPTS} != *"--offline"* ]]; then
     MIXER_OPTS="${MIXER_OPTS} --offline"
 fi
 
-mixer_cmd() {
-    # shellcheck disable=SC2086
-    mixer ${MIXER_OPTS} "${@}"
-}
-
-sudo_mixer_cmd() {
-    # shellcheck disable=SC2086
-    sudo -E mixer ${MIXER_OPTS} "${@}"
-}
-
 fetch_bundles() {
     log_line "Fetching bundles:"
     local bundles_dir="${WORK_DIR}/bundles"


### PR DESCRIPTION
The function wrappers for mixer should be put into common.sh so that
they are made available to other scripts.  Need to use a mixer function
wrapper when running MCA, which was forgotten on the previous commits.
There are no more cases after this one where mixer is called without a
function wrapper.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>