### PR TITLE
Add stubs for signing updates and images

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -24,6 +24,10 @@ assert_file() {
     [[ -f $1 ]] > /dev/null 2>&1 || { error "file '$1' not found"; exit 1; }
 }
 
+function_exists() {
+    [[ "$(type -t "${1}")" == 'function' ]]
+}
+
 silentkill () {
     if [ -n "$2" ]; then
         kill "$2" "$1" > /dev/null 2>&1 || true

--- a/globals.sh
+++ b/globals.sh
@@ -47,5 +47,5 @@ RELEASE_NOTES=release-notes
 # Space-separated
 LICENSES_FILTER=${LICENSES_FILTER-"and"}
 
-# sign_image requirements
+# Images
 CHKSUM_FILE_SUFFIX=${CHKSUM_FILE_SUFFIX:-"SHA512SUM"}

--- a/release/images.sh
+++ b/release/images.sh
@@ -37,9 +37,9 @@ checksum_and_sign() {
 
         _output+="${file} ${chksum_file} " # space is not a mistake
 
-        if [[ -n "${IMG_SIGN_CMD}" ]]; then
+        if function_exists sign_image; then
             log "Signing (custom)" "${chksum_file}"
-            "${IMG_SIGN_CMD}" "${chksum_file}" "${chksum_file}.sig"
+            sign_image "${chksum_file}" "${chksum_file}.sig"
         elif [[ -s "${IMG_SIGN_KEY}" ]]; then
             log "Signing (openssl)" "${chksum_file}"
             openssl dgst -sha1 -sign "${IMG_SIGN_KEY}" -out "${chksum_file}.sig" "${chksum_file}"

--- a/release/prologue.sh
+++ b/release/prologue.sh
@@ -27,6 +27,7 @@ LOG_INDENT=1 fetch_config_repo
 
 rm -rf "${WORK_DIR}"
 mkdir -p "${WORK_DIR}"/release/{config,images}
+
 mkdir -p "${PKGS_DIR}"
 
 mkdir -p "${MIXER_DIR}"
@@ -63,7 +64,28 @@ Upstream URL:
     ${CLR_PUBLIC_DL_URL}
 Upstream Bundles:
     ${CLR_BUNDLES:-"All"}
+EOL
 
+echo
+echo "== Signing =="
+echo "Custom update signing provided?"
+if function_exists sign_update; then
+    echo "    Yes!"
+    cp -f "${SWUPD_CERT:?"SWUPD_CERT Cannot be Null/Unset"}" "${MIXER_DIR}/Swupd_Root.pem"
+    echo "Swupd cert:"
+    echo "    ${SWUPD_CERT}"
+else
+    echo "    No!"
+fi
+echo "Custom image signing provided?"
+if function_exists sign_image; then
+    echo "    Yes!"
+else
+    echo "    No!"
+fi
+echo
+
+cat <<EOL
 == Workspace ==
 Namespace:
     ${NAMESPACE}


### PR DESCRIPTION
The signing solution required for each user of clr-distro-factory will
vary greatly.  A different solution may be needed for signing updates
than from signing images as well.

If a function is defined as a part of the user's configuration
repository, and this function has as a parameter interface the input and
output files as the first and second parameters, respectively, then this
function is used during the build process.  Users may define a
sign_update function as well as a sign_image function.

This abstracts the particular implementation of the signing solution
away from the build process and allows it to be defined entirely as a
configuration.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>