### PR TITLE
[globals] Fix PKGS_DIR path

### DIFF
--- a/globals.sh
+++ b/globals.sh
@@ -30,8 +30,8 @@ REPO_DIR="${WORK_DIR}/repo"
 VARS_DIR="${WORK_DIR}/.vars"
 
 BUILD_ARCH="${BUILD_ARCH:-x86_64}"
-PKGS_DIR="${REPO_DIR}/${BUILD_ARCH}/os/packages"
-PKGS_DIR_SUFFIX="repo/${BUILD_ARCH}/os/packages"
+PKGS_DIR_SUFFIX="${BUILD_ARCH}/os/packages"
+PKGS_DIR="${REPO_DIR}/${PKGS_DIR_SUFFIX}"
 
 BUILD_FILE=build-env
 BUNDLES_FILE=bundles-def


### PR DESCRIPTION
PKGS_DIR final path needs to be derived from PKGS_DIR_SUFFIX and
REPO_DIR to allow for customization to properly work (not only mixer.sh
but also for stage.sh).

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>