### PR TITLE
Rename DS_FORMAT shared variable to MIX_FORMAT

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -94,13 +94,13 @@ get_downstream_version() {
     DS_LATEST=$(cat "${STAGING_DIR}/latest" 2>/dev/null) || true
     if [[ -z "${DS_LATEST}" ]]; then
         info "Failed to fetch Downstream latest version. First Mix?"
-        DS_FORMAT="${CLR_FORMAT:-1}"
+        MIX_FORMAT="${CLR_FORMAT:-1}"
     elif ((${#DS_LATEST} < 4)); then
         error "Downstream Clear Linux version number seems corrupted."
         exit 2
     else
-        DS_FORMAT=$(cat "${STAGING_DIR}/update/${DS_LATEST}/format" 2>/dev/null) || true
-        if [[ -z "${DS_FORMAT}" ]]; then
+        MIX_FORMAT=$(cat "${STAGING_DIR}/update/${DS_LATEST}/format" 2>/dev/null) || true
+        if [[ -z "${MIX_FORMAT}" ]]; then
             error "Failed to fetch Downstream latest format."
             exit 2
         fi

--- a/release/images.sh
+++ b/release/images.sh
@@ -15,7 +15,7 @@ SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 . "${SCRIPT_DIR}/../config/config.sh"
 
 var_load MIX_VERSION
-var_load DS_FORMAT
+var_load MIX_FORMAT
 
 IMGS_DIR="${WORK_DIR}/release/images"
 LOG_DIR="${WORK_DIR}/logs"
@@ -104,7 +104,7 @@ create_image() {
     pushd "${WORK_DIR}" > /dev/null
 
     sudo -E clr-installer --config "${image}" --log-level=4 \
-        --swupd-format "${DS_FORMAT}" --swupd-clean \
+        --swupd-format "${MIX_FORMAT}" --swupd-clean \
         --swupd-cert "${MIXER_DIR}/Swupd_Root.pem" \
         --swupd-contenturl "file://${MIXER_DIR}/update/www" \
         --swupd-versionurl "file://${MIXER_DIR}/update/www" \
@@ -180,7 +180,7 @@ mkdir -p "${LOG_DIR}"
 export IMGS_DIR
 export LOG_DIR
 export MIX_VERSION
-export DS_FORMAT
+export MIX_FORMAT
 export SCRIPT_DIR
 export TEMPLATES_PATH
 export -f create_image

--- a/release/mixer.sh
+++ b/release/mixer.sh
@@ -260,7 +260,7 @@ format_bumps=$(( CLR_FORMAT - DS_UP_FORMAT ))
 for (( bump=0 ; bump < format_bumps ; bump++ )); do
     section "Format Bump: $(( bump + 1 )) of ${format_bumps}"
 
-    ds_fmt=$(( DS_FORMAT + bump ))
+    ds_fmt=$(( MIX_FORMAT + bump ))
     ds_fmt_next=$(( ds_fmt + 1 ))
     log "Downstream Format" "From: ${ds_fmt} To: ${ds_fmt_next}"
 
@@ -294,14 +294,14 @@ for (( bump=0 ; bump < format_bumps ; bump++ )); do
 done
 
 if [[ -n "${ds_fmt_next}" ]]; then
-    DS_FORMAT=${ds_fmt_next}
-    var_save DS_FORMAT
+    MIX_FORMAT=${ds_fmt_next}
+    var_save MIX_FORMAT
 fi
 
 if [[ -z "${ds_ver_next}" || "${MIX_VERSION}" -gt "${ds_ver_next}" ]]; then
     log_line
-    log "Regular Mix:" "${MIX_VERSION} (${DS_FORMAT}) based on: ${CLR_LATEST} (${CLR_FORMAT})"
-    generate_mix "${CLR_LATEST}" "${MIX_VERSION}" "${DS_FORMAT}"
+    log "Regular Mix:" "${MIX_VERSION} (${MIX_FORMAT}) based on: ${CLR_LATEST} (${CLR_FORMAT})"
+    generate_mix "${CLR_LATEST}" "${MIX_VERSION}" "${MIX_FORMAT}"
 
     MCA_VERSIONS+=" ${MIX_VERSION}"
 else

--- a/release/prologue.sh
+++ b/release/prologue.sh
@@ -110,7 +110,7 @@ get_latest_versions
 var_save CLR_FORMAT
 var_save CLR_LATEST
 var_save DS_DOWN_VERSION
-var_save DS_FORMAT
+var_save MIX_FORMAT
 var_save DS_LATEST
 var_save DS_UP_FORMAT
 var_save DS_UP_VERSION
@@ -121,7 +121,7 @@ echo "Latest Downstream version (format):"
 if [[ -z ${DS_LATEST} ]]; then
     echo "    First Mix! (0)"
 else
-    echo "    ${DS_UP_VERSION} ${DS_DOWN_VERSION} (${DS_FORMAT})"
+    echo "    ${DS_UP_VERSION} ${DS_DOWN_VERSION} (${MIX_FORMAT})"
     echo "Based on Upstream Version:"
     echo "    ${DS_UP_VERSION} (${DS_UP_FORMAT})"
 fi
@@ -134,7 +134,7 @@ var_save MIX_UP_VERSION
 var_save MIX_DOWN_VERSION
 
 echo "Next Downstream Version:"
-echo "    ${MIX_UP_VERSION} ${MIX_DOWN_VERSION} (${DS_FORMAT})"
+echo "    ${MIX_UP_VERSION} ${MIX_DOWN_VERSION} (${MIX_FORMAT})"
 echo "Should this build be a MIN version?"
 if ${MIN_VERSION}; then
     echo "    Yes!"

--- a/release/release_notes.sh
+++ b/release/release_notes.sh
@@ -14,7 +14,7 @@ SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 . ./config/config.sh
 
 var_load DS_DOWN_VERSION
-var_load DS_FORMAT
+var_load MIX_FORMAT
 var_load DS_LATEST
 var_load DS_UP_VERSION
 var_load MIX_VERSION
@@ -90,7 +90,7 @@ EOL
 
     if [[ -n ${DS_LATEST} ]]; then
         log "PREVIOUS VERSION" \
-            "${DS_UP_VERSION} ${DS_DOWN_VERSION} (${DS_FORMAT})" >> ${RELEASE_NOTES}
+            "${DS_UP_VERSION} ${DS_DOWN_VERSION} (${MIX_FORMAT})" >> ${RELEASE_NOTES}
         log_line >> ${RELEASE_NOTES}
     fi
 


### PR DESCRIPTION
Because clr-distro-factory is being converted to handle both upstream
and downstream use cases, need to start naming the most important shared
variables without an upstream vs downstream orientation.  Renaming the
DS_FORMAT to MIX_FORMAT.  This brings consistency with the MIX_VERSION
shared variable.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>