### PR TITLE
[common] Allow absolute paths for fetching git repos

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -45,18 +45,18 @@ fetch_git_repo() {
         return 1
     fi
 
-    if [[ ! -d "./${dir_name}" ]]; then
+    if [[ ! -d "${dir_name}" ]]; then
         log_line "Cloning..." 1
         git clone --quiet "${repo}" "${dir_name}"
         log_line "OK!" 2
     else
         log_line "Updating..." 1
-        git -C "./${dir_name}" fetch --prune -P --quiet origin
-        git -C "./${dir_name}" reset --hard --quiet origin/master
+        git -C "${dir_name}" fetch --prune -P --quiet origin
+        git -C "${dir_name}" reset --hard --quiet origin/master
         log_line "OK!" 2
     fi
 
-    log_line "$(git -C "./${dir_name}" remote get-url origin) ($(git -C "./${dir_name}" rev-parse --short HEAD))" 1
+    log_line "$(git -C "${dir_name}" remote get-url origin) ($(git -C "${dir_name}" rev-parse --short HEAD))" 1
 }
 
 fetch_config_repo() {


### PR DESCRIPTION
When supplying absolute paths when fetching git repos, the function will
fail because the derived directory will not exist.

Remove the assumption that the function is always working with the
current directory, since this is implied when not passed in shell.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>