### PR TITLE
[release] Fix pipeline file

### DIFF
--- a/build/BuildKojiPipeline
+++ b/build/BuildKojiPipeline
@@ -37,11 +37,6 @@ pipeline {
                 sh 'build/stage.sh'
             }
         }
-        stage('Publish') {
-            steps {
-                sh 'build/publish.sh'
-            }
-        }
     }
 
     post {

--- a/build/BuildPipeline
+++ b/build/BuildPipeline
@@ -37,11 +37,6 @@ pipeline {
                 sh 'build/stage.sh'
             }
         }
-        stage('Publish') {
-            steps {
-                sh 'build/publish.sh'
-            }
-        }
     }
 
     post {

--- a/release/ReleasePipeline
+++ b/release/ReleasePipeline
@@ -2,7 +2,6 @@ pipeline {
     agent { label 'clr-builders' }
 
     environment {
-        NAMESPACE = "${JOB_NAME}"
         WORK_DIR = "${WORKSPACE}/work"
     }
 


### PR DESCRIPTION
After splitting from build, the pipeline can no longer infere the
namespace. It needs to be provided as a parameter just as it is done for
'watcher' pipeline.