### PR TITLE
[build] Reset Mixer state to previous successful build

### DIFF
--- a/build/mixer.sh
+++ b/build/mixer.sh
@@ -227,6 +227,9 @@ if [[ -z "${DS_LATEST}" ]]; then
     log_line "Initializing Mixer Workspace"
     mixer_cmd init --upstream-url "${CLR_PUBLIC_DL_URL}" --upstream-version "${CLR_LATEST}"
     log_line ""
+else
+    echo "${DS_LATEST}" > mixversion
+    sed -i -E -e "s/(PREVIOUS_MIX_VERSION = )(.*)/\\1\"${DS_LATEST}\"/" mixer.state
 fi
 
 mixer_cmd config set Swupd.CONTENTURL "${DISTRO_URL}/update"


### PR DESCRIPTION
One key feature to not depend on chaining bad builds without having to
manually clean-up on mixer workspace is the ability to re-execute a
current mix version. This allow us to re-create a given mix, as long it
is the current, in cases where mixer believes it successfully create an
update but there was an escape. It may also be that input is discovered
to not be good after the fact, or even, that after update builds were
the one that caught our attention to flawed input.

With mixer 5.0.0, this kind of re-run, as long it was with the same
version than it was found on 'mixversion' it was not an issue. Now mixer
6 is complaining if you try to use the same mixversion as last run, even
if the run was not successful.

Therefore, this patch provides the workaround necessary to re-stablish
this feature that is key for operations.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>