### PR TITLE
[mixer] Inject Swupd_Root.pem when custom signing

### DIFF
--- a/build/mixer.sh
+++ b/build/mixer.sh
@@ -24,6 +24,8 @@ if ! "${IS_DOWNSTREAM}" && [[ ${MIXER_OPTS} != *"--offline"* ]]; then
 fi
 
 build_bundles() {
+    local mix_ver="$1"
+
     section "Bundles"
     log_line "Updating Bundles List:"
     # Clean bundles file, otherwise mixer will use the outdated list
@@ -52,6 +54,19 @@ build_bundles() {
     # shellcheck disable=SC2086
     sudo_mixer_cmd build bundles ${mixer_opts_bundles}
     log_line
+
+    if function_exists sign_update; then
+        log_line "Injecting Swupd_Root.pem into full chroot"
+        local chroot_cert_file="/usr/share/clear/update-ca/Swupd_Root.pem"
+        local chroot_cert_dir="$(dirname "${chroot_cert_file}")"
+        local mix_ver_chroot_dir="update/image/${mix_ver}/full"
+        sudo mkdir -p "${mix_ver_chroot_dir}${chroot_cert_dir}"
+        sudo cp -f Swupd_Root.pem "${mix_ver_chroot_dir}${chroot_cert_file}"
+        echo "${chroot_cert_dir}" > update/os-core-update-extra-files
+        echo "${chroot_cert_file}" >> update/os-core-update-extra-files
+    else
+        rm -f update/os-core-update-extra-files
+    fi
 }
 
 build_update() {
@@ -139,7 +154,7 @@ generate_bump() {
     # shellcheck disable=SC2086
     mixer_cmd versions update ${mixer_opts}
 
-    build_bundles
+    build_bundles "${mix_ver}"
 
     # Remove bundles pending deletion
     section "Bundle Deletion"
@@ -224,7 +239,7 @@ generate_mix() {
     # shellcheck disable=SC2086
     mixer_cmd versions update ${mixer_opts}
 
-    build_bundles
+    build_bundles "${mix_ver}"
 
     build_update "${mix_ver}"
 


### PR DESCRIPTION
When a user is replacing the signing function of mixer with their own
custom implementation, which implies the `--no-signing` option is being
used, the user is also responsible for injecting the Swupd_Root.pem into
the full chroot.  This is required because swupd is hard-coded by
default to look for the update content certificate in
/usr/share/clear/update-ca/Swupd_Root.pem.

Mixer has a not well-documented feature to support adding sideloaded
content that does not come from a package by creating files in the
SERVER_STATE_DIR which the name `<bundle>-extra-files`.  Because the
content certificate is required for swupd, we inject into the
os-core-update bundle.

Closes #85 

Signed-off-by: George T Kramer <george.t.kramer@intel.com>