### PR TITLE
[mixer] Don't fail on repo remove

### DIFF
--- a/build/mixer.sh
+++ b/build/mixer.sh
@@ -339,7 +339,7 @@ fi
 
 if ! "${IS_DOWNSTREAM}"; then
     log_line "Making sure 'clear' repo does not exists:"
-    mixer_cmd repo remove "clear"
+    mixer_cmd repo remove "clear" || true
 fi
 
 mixer_cmd config set Swupd.CONTENTURL "${DISTRO_URL}/update"


### PR DESCRIPTION
After Mixer 6.1.3 release, instead of no-op, 'repo remove' command will
fail if the repo was already removed. From 'distro-factory' point of
view, we can just ignore.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>