### PR TITLE
[mca]: Support variable table width

### DIFF
--- a/build/mca-check.sh
+++ b/build/mca-check.sh
@@ -36,7 +36,7 @@ fi
 pushd "${MIXER_DIR}" > /dev/null
 prev_ver="${mca_versions[0]}"
 for ver in "${mca_versions[@]:1}"; do
-    args="--from ${prev_ver} --to ${ver}"
+    args="--from ${prev_ver} --to ${ver} --table-width ${MCA_TABLE_WIDTH}"
     mca_log="${WORK_DIR}/${MCA_FILE}-${prev_ver}-${ver}.txt"
 
     # The custom content repo for the initial previous version is

--- a/globals.sh
+++ b/globals.sh
@@ -28,6 +28,8 @@ MIXER_OPTS=${MIXER_OPTS:-""}
 NUM_DELTA_BUILDS=${NUM_DELTA_BUILDS:-10}
 # Supported Mixer Version
 MIXER_MAJOR_VER=${MIXER_MAJOR_VER:-6}
+# Width of MCA statistics table
+MCA_TABLE_WIDTH=${MCA_TABLE_WIDTH:-120}
 
 # Workspace
 BUNDLES_DIR=${BUNDLES_DIR:-"${WORK_DIR}/bundles"}


### PR DESCRIPTION
The width of the MCA statistics table can be adjusted with the
MCA_TABLE_WIDTH environment variable. The default value of 0 uses the
terminal width as the max table width.