### PR TITLE
[mixer] Set log file for mixer

### DIFF
--- a/build/init-env.sh
+++ b/build/init-env.sh
@@ -162,9 +162,10 @@ Swupd Version:
 
 EOL
 
-mixer_major_ver=$(mixer --version | sed -E -e 's/.*([0-9]+).[0-9]+.[0-9]+$/\1/')
-if (( mixer_major_ver < MIXER_MAJOR_VER )); then
-    error "Unsupported Mixer Version" "Mixer major version needs to be ${MIXER_MAJOR_VER} or greater"
+mixer_ver_abs=$(mixer --version | sed -E -e 's/([A-Z][a-z]+ )([0-9]+)(.)([0-9]+)(.)([0-9]+)/\2\4\6/')
+mixer_ver_min_abs=$(echo "${MIXER_VER_MIN}" | sed -E -e 's/([0-9]+)(.)([0-9]+)(.)([0-9]+)/\1\3\5/')
+if (( mixer_ver_abs < mixer_ver_min_abs )); then
+    error "Unsupported Mixer Version" "Mixer version needs to be ${MIXER_VER_MIN} or greater"
     error "Aborting build to avoid corrupting your mixer workspace"
     exit 1
 fi

--- a/build/mixer.sh
+++ b/build/mixer.sh
@@ -18,6 +18,7 @@ SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 
 var_load_all
 
+MIXER_LOG=${MIXER_LOG:-"mixer-tools.log"}
 CONTENT_URL=${CONTENT_URL:-"${DISTRO_URL}/update"}
 VERSION_URL=${VERSION_URL:-"${DISTRO_URL}/update"}
 
@@ -360,6 +361,7 @@ if ! "${IS_DOWNSTREAM}"; then
     mixer_cmd repo remove "clear" || true
 fi
 
+mixer_cmd config set Mixer.LOG "${MIXER_LOG}"
 mixer_cmd config set Swupd.CONTENTURL "${CONTENT_URL}"
 mixer_cmd config set Swupd.VERSIONURL "${VERSION_URL}"
 

--- a/globals.sh
+++ b/globals.sh
@@ -26,8 +26,9 @@ MIX_INCREMENT=${MIX_INCREMENT:-10}
 MIXER_OPTS=${MIXER_OPTS:-""}
 # Number of builds from the current build to generate deltas
 NUM_DELTA_BUILDS=${NUM_DELTA_BUILDS:-10}
-# Supported Mixer Version
-MIXER_MAJOR_VER=${MIXER_MAJOR_VER:-6}
+# Minimum version of mixer that is supported
+MIXER_VER_MIN=${MIXER_VER_MIN:-6.2.3}
+
 # Width of MCA statistics table
 MCA_TABLE_WIDTH=${MCA_TABLE_WIDTH:-120}
 


### PR DESCRIPTION
**Note: BLOCKED until mixer-tools v6.2.3 is included in the Clear Linux build.**

mixer-tools v6.2.3 supports logging.
Turn on this feature to help debug issues.
A log file appended with timestamp will be created for each run.

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>