### PR TITLE
[content] Always create content repo

### DIFF
--- a/build/content.sh
+++ b/build/content.sh
@@ -26,7 +26,6 @@ log_line "OK!" 1
 section "Creating Content Repository"
 if [[ -z "$(ls -A "${PKGS_DIR}")" ]]; then
     info "Custom Content Not Found" " '${PKGS_DIR}' is empty."
-    exit 0
 fi
 
 log_line # Output too verbose


### PR DESCRIPTION
Currently the CI is failing because MCA is trying to fetch from a
content repo that does not exist. There are several ways to handle this, one of them
being to always create the content repo even if there are no packages.

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>