### PR TITLE
[ci] Update to GitHub Actions v2.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,14 @@ jobs:
   static-analysis:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2.1.0
     - name: make check
       run: make check
 
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2.1.0
     - name: Build Docker Image
       run:
         docker build --quiet --build-arg UID=$(id -u) --network host --force-rm -t clr-builder .github/docker


### PR DESCRIPTION
Fix CI rebuilds by updating to GitHub Actions v2.1.0

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>